### PR TITLE
Removed deprecated ssl.wrap_socket

### DIFF
--- a/kicost_digikey_api_v3/oauth/oauth2.py
+++ b/kicost_digikey_api_v3/oauth/oauth2.py
@@ -273,7 +273,14 @@ class TokenHandler:
                     ('localhost', PORT),
                     lambda request, address, server: HTTPServerHandler(
                         request, address, server, self._id, self._secret))
-            httpd.socket = ssl.wrap_socket(httpd.socket, certfile=filename, server_side=True)
+
+            ssl_version=ssl.PROTOCOL_TLS
+            certfile=filename
+            context = ssl.SSLContext(ssl_version)
+            context.load_cert_chain(certfile, None)
+
+            httpd.socket = context.wrap_socket(httpd.socket, server_side=True, server_hostname=None)
+
             httpd.stop = 0
 
             # This function will block until it receives a request


### PR DESCRIPTION
I took a stab at removing the deprecated ssl.wrap_socket.

I'm not very good at Python or all this web stuff is definitely too high-level for me, so I might have done more harm than good, so feel free to reject it if you think more stuff is needed.

I tested it on Python 3.12 and now KiCost can retrieve data from Digikey again.

I tried to fix the `test_production` example but that's way beyond my capabilities.